### PR TITLE
fix: build eslint-plugin-jsdoc before publish

### DIFF
--- a/packages/eslint-plugin-jsdoc/package.json
+++ b/packages/eslint-plugin-jsdoc/package.json
@@ -70,6 +70,7 @@
     "tsc-build": "tsc -p tsconfig-prod.json",
     "tsc-cjs": "tsc -p tsconfig-cjs.json",
     "rollup": "rollup -c",
+    "prepublishOnly": "pnpm run build",
     "build": "node ./src/bin/buildEntryFileForTS.js && rimraf ./dist && mkdir dist && pnpm run rollup && cross-env NODE_ENV=production babel ./src --out-file-extension .cjs --out-dir ./dist --copy-files --source-maps --ignore ./src/bin/*.js --no-copy-ignored && node ./scripts/replaceImports.js && pnpm run tsc-build && pnpm run tsc-cjs",
     "check-docs": "node ./src/bin/generateDocs.js --check",
     "create-docs": "pnpm run create-options && node ./src/bin/generateDocs.js && pnpm run ruleTypes",


### PR DESCRIPTION
Add `prepublishOnly` to `@ox-jsdoc/eslint-plugin-jsdoc` so `pnpm publish` always runs `pnpm run build` first.

Release workflow publishes this package directly with `pnpm publish`, and without this hook, built `dist` artifacts can be omitted.
This can make installed packages miss plugin entry files.

This change makes the package self-contained at publish time by guaranteeing compilation output is included every time the package is published.
