### PR TITLE
fix(eslint-plugin-jsdoc): port upstream rule fixes

### DIFF
--- a/packages/eslint-plugin-jsdoc/src/iterateJsdoc.js
+++ b/packages/eslint-plugin-jsdoc/src/iterateJsdoc.js
@@ -339,6 +339,7 @@ import esquery from 'esquery';
 
 /**
  * @callback AvoidDocs
+ * @param {boolean} [exemptSpecialMethods]
  * @returns {boolean}
  */
 
@@ -1464,7 +1465,9 @@ const getUtils = (
   };
 
   /** @type {AvoidDocs} */
-  utils.avoidDocs = () => {
+  utils.avoidDocs = (
+    exemptSpecialMethods = true,
+  ) => {
     if (
       ignoreReplacesDocs !== false &&
         (utils.hasTag('ignore') || utils.classHasTag('ignore')) ||
@@ -1482,7 +1485,7 @@ const getUtils = (
       return true;
     }
 
-    if (jsdocUtils.exemptSpeciaMethods(
+    if (exemptSpecialMethods && jsdocUtils.exemptSpeciaMethods(
       jsdoc,
       node,
       context,

--- a/packages/eslint-plugin-jsdoc/src/jsdocUtils.js
+++ b/packages/eslint-plugin-jsdoc/src/jsdocUtils.js
@@ -6,6 +6,9 @@ import {
 } from './tagNames.js';
 import WarnSettings from './WarnSettings.js';
 import {
+  parseCommentForSource,
+} from './parseCommentStrategy.js';
+import {
   stringify,
   tryParse,
 } from '@ox-jsdoc/jsdoccomment';
@@ -1085,6 +1088,43 @@ const isNameOrNamepathDefiningTag = (tag, tagMap = tagStructure) => {
 };
 
 /**
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {import('./parseCommentStrategy.js').ParseSettings} settings
+ * @returns {import('@ox-jsdoc/jsdoccomment').JsdocBlockWithInline[]}
+ */
+const getJSDocCommentBlocks = (sourceCode, settings) => {
+  return sourceCode.getAllComments()
+    .filter((comment) => {
+      return (/^\*(?!\*)/v).test(comment.value);
+    })
+    .map((commentNode) => {
+      return parseCommentForSource(sourceCode, commentNode, settings, '');
+    });
+};
+
+/**
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {import('./parseCommentStrategy.js').ParseSettings} settings
+ * @returns {import('comment-parser').Spec[]}
+ */
+const getDocumentNamepathDefiningTags = (sourceCode, settings) => {
+  return getJSDocCommentBlocks(sourceCode, settings)
+    .flatMap((doc) => {
+      return doc.tags.filter(({
+        tag,
+      }) => {
+        return isNameOrNamepathDefiningTag(tag) && ![
+          'arg',
+          'argument',
+          'param',
+          'prop',
+          'property',
+        ].includes(tag);
+      });
+    });
+};
+
+/**
  * @param {string} tag
  * @param {import('./getDefaultTagStructureForMode.js').TagStructure} tagMap
  * @returns {boolean}
@@ -2110,9 +2150,11 @@ export {
   forEachPreferredTag,
   getAllTags,
   getContextObject,
+  getDocumentNamepathDefiningTags,
   getFunctionParameterNames,
   getIndent,
   getInlineTags,
+  getJSDocCommentBlocks,
   getJsdocTagsDeep,
   getPreferredTagName,
   getPreferredTagNameSimple,

--- a/packages/eslint-plugin-jsdoc/src/rules/emptyTags.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/emptyTags.js
@@ -55,6 +55,14 @@ export default iterateJsdoc(({
       // Allow for JSDoc-block final asterisks
       key !== emptyTags.length - 1 || !(/^\s*\*+$/v).test(content)
     )) {
+      const {
+        tokens: {
+          delimiter,
+          end,
+          postName,
+          start,
+        },
+      } = tag.source[0];
       const fix = () => {
         // By time of call in fixer, `tag` will have `line` added
         utils.setTag(
@@ -63,6 +71,12 @@ export default iterateJsdoc(({
            *   line: import('../iterateJsdoc.js').Integer
            * }}
            */ (tag),
+          {
+            delimiter,
+            end,
+            postName: end ? postName : '',
+            start,
+          },
         );
       };
 

--- a/packages/eslint-plugin-jsdoc/src/rules/noUndefinedTypes.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/noUndefinedTypes.js
@@ -3,6 +3,10 @@ import {
   parseCommentForSource,
 } from '../parseCommentStrategy.js';
 import {
+  getDocumentNamepathDefiningTags,
+  getJSDocCommentBlocks,
+} from '../jsdocUtils.js';
+import {
   getJSDocComment,
   parse as parseType,
   traverse,
@@ -124,13 +128,7 @@ export default iterateJsdoc(({
   }
 
   const allComments = sourceCode.getAllComments();
-  const comments = allComments
-    .filter((comment) => {
-      return (/^\*(?!\*)/v).test(comment.value);
-    })
-    .map((commentNode) => {
-      return parseCommentForSource(sourceCode, commentNode, settings, '');
-    });
+  const comments = getJSDocCommentBlocks(sourceCode, settings);
 
   const globals = allComments
     .filter((comment) => {
@@ -139,20 +137,7 @@ export default iterateJsdoc(({
       return commentNode.value.replace(/^\s*globals/v, '').trim().split(/,\s*/v);
     }).concat(Object.keys(context.languageOptions.globals ?? []));
 
-  const typedefs = comments
-    .flatMap((doc) => {
-      return doc.tags.filter(({
-        tag,
-      }) => {
-        return utils.isNameOrNamepathDefiningTag(tag) && ![
-          'arg',
-          'argument',
-          'param',
-          'prop',
-          'property',
-        ].includes(tag);
-      });
-    });
+  const typedefs = getDocumentNamepathDefiningTags(sourceCode, settings);
 
   const typedefDeclarations = typedefs
     .map((tag) => {

--- a/packages/eslint-plugin-jsdoc/src/rules/requireReturnsCheck.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/requireReturnsCheck.js
@@ -1,7 +1,27 @@
 import iterateJsdoc from '../iterateJsdoc.js';
 import {
+  getDocumentNamepathDefiningTags,
   strictNativeTypes,
 } from '../jsdocUtils.js';
+import {
+  traverse,
+  tryParse as tryParseType,
+} from '@ox-jsdoc/jsdoccomment';
+
+/**
+ * @type {Partial<Record<import('../jsdocUtils.js').ParserMode, import('jsdoc-type-pratt-parser').ParseMode[]>>}
+ */
+const parseTypeModes = {
+  closure: [
+    'closure',
+  ],
+  jsdoc: [
+    'jsdoc',
+  ],
+  typescript: [
+    'typescript',
+  ],
+};
 
 /**
  * @param {import('../iterateJsdoc.js').Utils} utils
@@ -36,11 +56,35 @@ const canSkip = (utils, settings) => {
     settings.mode === 'closure' && utils.classHasTag('record');
 };
 
+/**
+ * @param {import('jsdoc-type-pratt-parser').RootResult} parsedType
+ * @returns {import('jsdoc-type-pratt-parser').RootResult}
+ */
+const getReturnTypeLevelNode = (parsedType) => {
+  return parsedType.type === 'JsdocTypeParenthesis' ?
+    parsedType.element :
+    parsedType;
+};
+
+/**
+ * @param {import('eslint').Rule.RuleContext} context
+ * @param {import('../jsdocUtils.js').ParserMode} mode
+ * @returns {import('../jsdocUtils.js').ParserMode}
+ */
+const getParseMode = (context, mode) => {
+  const {
+    jsdoc,
+  } = /** @type {{jsdoc?: {mode?: import('../jsdocUtils.js').ParserMode}}} */ (context.settings);
+
+  return jsdoc?.mode ?? mode;
+};
+
 export default iterateJsdoc(({
   context,
   node,
   report,
   settings,
+  sourceCode,
   utils,
 }) => {
   const {
@@ -49,6 +93,10 @@ export default iterateJsdoc(({
     noNativeTypes = true,
     reportMissingReturnForUndefinedTypes = false,
   } = context.options[0] || {};
+  const {
+    mode,
+  } = settings;
+  const parseMode = getParseMode(context, mode);
 
   if (canSkip(utils, settings)) {
     return;
@@ -90,6 +138,67 @@ export default iterateJsdoc(({
   }
 
   const returnNever = type === 'never';
+  const typedefs = getDocumentNamepathDefiningTags(sourceCode, settings);
+
+  /**
+   * @param {import('comment-parser').Spec} returnTag
+   * @returns {boolean}
+   */
+  const mayReturnUndefined = (returnTag) => {
+    if (utils.mayBeUndefinedTypeTag(returnTag)) {
+      return true;
+    }
+
+    const returnType = returnTag.type.trim();
+    let parsedType;
+    try {
+      parsedType = tryParseType(returnType, parseTypeModes[parseMode]);
+    } catch {
+      return false;
+    }
+
+    const returnTypeLevelNode = getReturnTypeLevelNode(parsedType);
+    let returnIsUndefined = false;
+    traverse(returnTypeLevelNode, (nde, parentNode) => {
+      const isReturnLevelNode = !parentNode ||
+        returnTypeLevelNode.type === 'JsdocTypeUnion' && parentNode === returnTypeLevelNode;
+      if (!isReturnLevelNode) {
+        return;
+      }
+
+      const {
+        type: nodeType,
+      } = /** @type {import('jsdoc-type-pratt-parser').RootResult} */ (nde);
+
+      if (nodeType === 'JsdocTypeUndefined') {
+        returnIsUndefined = true;
+        return;
+      }
+
+      if (nodeType !== 'JsdocTypeName') {
+        return;
+      }
+
+      const {
+        value,
+      } = /** @type {import('jsdoc-type-pratt-parser').NameResult} */ (nde);
+
+      if (value === 'void') {
+        returnIsUndefined = true;
+        return;
+      }
+
+      const referencedTypedef = typedefs.find((typedefTag) => {
+        return typedefTag.name === value;
+      });
+
+      if (referencedTypedef && utils.mayBeUndefinedTypeTag(referencedTypedef)) {
+        returnIsUndefined = true;
+      }
+    });
+
+    return returnIsUndefined;
+  };
 
   if (returnNever && utils.hasValueOrExecutorHasNonEmptyResolveValue(false)) {
     report(`JSDoc @${tagName} declaration set with "never" but return expression is present in function.`);
@@ -107,7 +216,7 @@ export default iterateJsdoc(({
     !returnNever &&
     (
       reportMissingReturnForUndefinedTypes ||
-      !utils.mayBeUndefinedTypeTag(tag)
+      !mayReturnUndefined(tag)
     ) &&
     (tag.type === '' && !utils.hasValueOrExecutorHasNonEmptyResolveValue(
       exemptAsync,

--- a/packages/eslint-plugin-jsdoc/src/rules/requireThrows.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/requireThrows.js
@@ -19,7 +19,7 @@ const canSkip = (utils) => {
     // The designated type can itself document `@throws`
     'type',
   ]) ||
-    utils.avoidDocs();
+    utils.avoidDocs(false);
 };
 
 export default iterateJsdoc(({

--- a/packages/eslint-plugin-jsdoc/test/rules/assertions/emptyTags.js
+++ b/packages/eslint-plugin-jsdoc/test/rules/assertions/emptyTags.js
@@ -215,6 +215,22 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       },
     },
+    {
+      code: `
+        /** @private A */
+        const a = "a";
+      `,
+      errors: [
+        {
+          line: 2,
+          message: '@private should be empty.',
+        },
+      ],
+      output: `
+        /** @private */
+        const a = "a";
+      `,
+    },
   ],
   valid: [
     {

--- a/packages/eslint-plugin-jsdoc/test/rules/assertions/requireReturnsCheck.js
+++ b/packages/eslint-plugin-jsdoc/test/rules/assertions/requireReturnsCheck.js
@@ -685,6 +685,72 @@ export default /** @type {import('../index.js').TestCases} */ ({
         },
       ],
     },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return;
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|string} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return;
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {Array<MaybeResult|void>} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return;
+        }
+      };
+      `,
+      errors: [
+        {
+          line: 6,
+          message: 'JSDoc @returns declaration present but return expression not available in function.',
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -1474,6 +1540,162 @@ export default /** @type {import('../index.js').TestCases} */ ({
           mode: 'permissive',
         },
       },
+    },
+    {
+      code: `
+      /**
+       * @param {string} name
+       *
+       * @typedef {{ loadTime: number; runTime: number; totalTime: number } | void} PerfResult
+       * @returns {PerfResult} Perf result
+       */
+      const perfCase = name => {
+        const loadStartTime = performance.now();
+
+        let syncFn;
+
+        try {
+          syncFn = require(\`./\${name}.cjs\`);
+        } catch {
+          return;
+        }
+
+        const loadTime = performance.now() - loadStartTime;
+
+        let i = RUN_TIMES;
+
+        const runStartTime = performance.now();
+
+        while (i-- > 0) {
+          syncFn(__filename);
+        }
+
+        const runTime = performance.now() - runStartTime;
+
+        return {
+          loadTime,
+          runTime,
+          totalTime: runTime + loadTime,
+        };
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+      settings: {
+        jsdoc: {
+          mode: 'permissive',
+        },
+      },
+    },
+    {
+      code: `
+      /**
+       * @returns {MaybeResult} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+
+      /**
+       * @typedef {{ ok: boolean } | void} MaybeResult
+       */
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean } | undefined} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|string} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {MaybeResult|void} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {(MaybeResult|void)} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
+    },
+    {
+      code: `
+      /**
+       * @typedef {{ ok: boolean }} MaybeResult
+       */
+
+      /**
+       * @returns {(MaybeResult|undefined)} Result.
+       */
+      const maybeResult = () => {
+        if (Math.random() > 0.5) {
+          return { ok: true };
+        }
+      };
+      `,
     },
     {
       code: `

--- a/packages/eslint-plugin-jsdoc/test/rules/assertions/requireThrows.js
+++ b/packages/eslint-plugin-jsdoc/test/rules/assertions/requireThrows.js
@@ -18,6 +18,24 @@ export default /** @type {import('../index.js').TestCases} */ ({
     },
     {
       code: `
+        class Quux {
+          /**
+           *
+           */
+          constructor (foo) {
+            throw new Error('err')
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          message: 'Missing JSDoc @throws declaration.',
+        },
+      ],
+    },
+    {
+      code: `
           /**
            *
            */


### PR DESCRIPTION
Ports selected upstream eslint-plugin-jsdoc rule fixes into the fork while preserving the `@ox-jsdoc/jsdoccomment` parser path and `parseCommentForSource` batching strategy.

This improves require-returns-check for typedefs, top-level unions, void, and undefined; preserves token data in empty-tags autofixes, lets require-throws report constructor throws; and shares JSDoc typedef collection with no-undefined-types.