### PR TITLE
fix(eslint-plugin-jsdoc): make eslint runtime optional

### DIFF
--- a/packages/eslint-plugin-jsdoc/package.json
+++ b/packages/eslint-plugin-jsdoc/package.json
@@ -149,6 +149,11 @@
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
   },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
+  },
   "lint-staged": {
     "*.js": "eslint --fix"
   },

--- a/packages/eslint-plugin-jsdoc/src/index-cjs.js
+++ b/packages/eslint-plugin-jsdoc/src/index-cjs.js
@@ -7,6 +7,9 @@ import {
 import {
   getJsdocProcessorPlugin,
 } from './getJsdocProcessorPlugin.js';
+import {
+  createRequire,
+} from 'node:module';
 import checkAccess from './rules/checkAccess.js';
 import checkAlignment from './rules/checkAlignment.js';
 import checkExamples from './rules/checkExamples.js';
@@ -73,10 +76,20 @@ import tsNoUnnecessaryTemplateExpression from './rules/tsNoUnnecessaryTemplateEx
 import tsPreferFunctionType from './rules/tsPreferFunctionType.js';
 import typeFormatting from './rules/typeFormatting.js';
 import validTypes from './rules/validTypes.js';
-import {
-  ESLint,
-} from 'eslint';
 import semver from 'semver';
+
+const requireFromHere = createRequire(import.meta.url);
+
+const getOptionalEslintVersion = () => {
+  try {
+    const eslint = requireFromHere('eslint');
+    return eslint.ESLint?.version ?? eslint.Linter?.version ?? '9.0.0';
+  } catch {
+    return '9.0.0';
+  }
+};
+
+const eslintVersion = getOptionalEslintVersion();
 
 /**
  * @typedef {"recommended" | "stylistic" | "contents" | "logical" | "requirements"} ConfigGroups
@@ -641,7 +654,7 @@ index.configs.examples = /** @type {import('eslint').Linter.Config[]} */ ([
       'no-console': 0,
 
       /* c8 ignore next 11 -- Coercion should work */
-      ...(semver.gte(semver.coerce(ESLint.version) ?? '9.0.0', '9.0.0') ? {} : {
+      ...(semver.gte(semver.coerce(eslintVersion) ?? '9.0.0', '9.0.0') ? {} : {
         // "always" newline rule at end unlikely in sample code
         'eol-last': 0,
 
@@ -699,7 +712,7 @@ index.configs['default-expressions'] = /** @type {import('eslint').Linter.Config
       'no-new': 0,
       'no-unused-expressions': 0,
       /* c8 ignore next 8 -- Coercion should work */
-      ...(semver.gte(semver.coerce(ESLint.version) ?? '9.0.0', '9.0.0') ? {} : {
+      ...(semver.gte(semver.coerce(eslintVersion) ?? '9.0.0', '9.0.0') ? {} : {
         quotes: [
           'error', 'double',
         ],

--- a/packages/eslint-plugin-jsdoc/src/index.js
+++ b/packages/eslint-plugin-jsdoc/src/index.js
@@ -13,6 +13,9 @@ import {
 import {
   getJsdocProcessorPlugin,
 } from './getJsdocProcessorPlugin.js';
+import {
+  createRequire,
+} from 'node:module';
 import checkAccess from './rules/checkAccess.js';
 import checkAlignment from './rules/checkAlignment.js';
 import checkExamples from './rules/checkExamples.js';
@@ -79,10 +82,20 @@ import tsNoUnnecessaryTemplateExpression from './rules/tsNoUnnecessaryTemplateEx
 import tsPreferFunctionType from './rules/tsPreferFunctionType.js';
 import typeFormatting from './rules/typeFormatting.js';
 import validTypes from './rules/validTypes.js';
-import {
-  ESLint,
-} from 'eslint';
 import semver from 'semver';
+
+const requireFromHere = createRequire(import.meta.url);
+
+const getOptionalEslintVersion = () => {
+  try {
+    const eslint = requireFromHere('eslint');
+    return eslint.ESLint?.version ?? eslint.Linter?.version ?? '9.0.0';
+  } catch {
+    return '9.0.0';
+  }
+};
+
+const eslintVersion = getOptionalEslintVersion();
 
 /**
  * @typedef {"recommended" | "stylistic" | "contents" | "logical" | "requirements"} ConfigGroups
@@ -647,7 +660,7 @@ index.configs.examples = /** @type {import('eslint').Linter.Config[]} */ ([
       'no-console': 0,
 
       /* c8 ignore next 11 -- Coercion should work */
-      ...(semver.gte(semver.coerce(ESLint.version) ?? '9.0.0', '9.0.0') ? {} : {
+      ...(semver.gte(semver.coerce(eslintVersion) ?? '9.0.0', '9.0.0') ? {} : {
         // "always" newline rule at end unlikely in sample code
         'eol-last': 0,
 
@@ -705,7 +718,7 @@ index.configs['default-expressions'] = /** @type {import('eslint').Linter.Config
       'no-new': 0,
       'no-unused-expressions': 0,
       /* c8 ignore next 8 -- Coercion should work */
-      ...(semver.gte(semver.coerce(ESLint.version) ?? '9.0.0', '9.0.0') ? {} : {
+      ...(semver.gte(semver.coerce(eslintVersion) ?? '9.0.0', '9.0.0') ? {} : {
         quotes: [
           'error', 'double',
         ],

--- a/packages/eslint-plugin-jsdoc/src/rules/checkExamples.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/checkExamples.js
@@ -1,13 +1,18 @@
 import iterateJsdoc from '../iterateJsdoc.js';
-import eslint, {
-  ESLint,
-} from 'eslint';
+import {
+  createRequire,
+} from 'node:module';
 import semver from 'semver';
 
-const {
-  // @ts-expect-error Older ESLint
-  CLIEngine,
-} = eslint;
+const requireFromHere = createRequire(import.meta.url);
+
+const loadEslint = () => {
+  try {
+    return requireFromHere('eslint');
+  } catch {
+    return null;
+  }
+};
 
 const zeroBasedLineIndexAdjust = -1;
 const likelyNestedJSDocIndentSpace = 1;
@@ -136,6 +141,26 @@ export default iterateJsdoc(({
   report,
   utils,
 }) => {
+  const eslint = loadEslint();
+
+  if (!eslint) {
+    report(
+      'This rule requires ESLint to be installed; you should disable this rule or install ESLint.',
+      null,
+      {
+        column: 1,
+        line: 1,
+      },
+    );
+
+    return;
+  }
+
+  const {
+    CLIEngine,
+    ESLint,
+  } = eslint;
+
   if (semver.gte(ESLint.version, '8.0.0')) {
     report(
       'This rule does not work for ESLint 8+; you should disable this rule and use' +

--- a/packages/eslint-plugin-jsdoc/src/rules/preferImportTag.js
+++ b/packages/eslint-plugin-jsdoc/src/rules/preferImportTag.js
@@ -12,13 +12,23 @@ import {
   tryParse as tryParseType,
 } from '@ox-jsdoc/jsdoccomment';
 import {
-  Linter,
-} from 'eslint';
+  createRequire,
+} from 'node:module';
 import {
   parseImportsExports,
 } from 'parse-imports-exports';
 import semver from 'semver';
 import toValidIdentifier from 'to-valid-identifier';
+
+const requireFromHere = createRequire(import.meta.url);
+
+const getOptionalLinterVersion = () => {
+  try {
+    return requireFromHere('eslint').Linter?.version ?? '10.0.0';
+  } catch {
+    return '10.0.0';
+  }
+};
 
 export default iterateJsdoc(({
   context,
@@ -92,7 +102,7 @@ export default iterateJsdoc(({
       }
 
       // For ESLint < 10, use the simple approach of inserting before programNode
-      if (semver.lt(Linter.version, '10.0.0')) {
+      if (semver.lt(getOptionalLinterVersion(), '10.0.0')) {
         return fixer.insertTextBefore(
           programNode,
           importText,


### PR DESCRIPTION
## Summary

Remove top-level runtime imports of eslint from the ESM entry and affected rules so `@ox-jsdoc/eslint-plugin-jsdoc` can load as an oxlint JS plugin when ESLint is not installed in the consuming project.

ESLint is now resolved lazily with safe version fallbacks, check-examples reports a clear rule-level error when ESLint is required, and the eslint peer is marked optional.

This fixes the secondary load failure seen through `@kazupon/vp-config`; preset-side bare specifier resolution remains a separate follow-up.
